### PR TITLE
Async AI draft generation and Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.git
+.worktrees
+worktrees
+coverage
+dist
+out
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/persona_seq"
 NEXTAUTH_SECRET="replace-with-a-local-secret"
 NEXTAUTH_URL="http://localhost:3000"
+
+# AI: mock = 不调外部接口；openai = OpenAI 兼容 Chat Completions（需 AI_API_KEY）
 AI_PROVIDER="mock"
 AI_API_KEY=""
+# 可选：兼容网关根路径（默认 https://api.openai.com/v1），如 DeepSeek: https://api.deepseek.com/v1
+# AI_BASE_URL="https://api.openai.com/v1"
+# 可选：模型名（默认 gpt-4o-mini）
+# AI_MODEL="gpt-4o-mini"
+# 可选：请求超时毫秒（默认 120000）
+# AI_TIMEOUT_MS="120000"
+# 可选：输出 token 上限（默认 2200）
+# AI_MAX_TOKENS="2200"
+# 可选：温度（0-1，默认 0.35）
+# AI_TEMPERATURE="0.35"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Override with build-arg when Docker Hub is unreachable, e.g.
+# NODE_IMAGE=mirror.gcr.io/library/node:22-bookworm-slim
+ARG NODE_IMAGE=node:22-bookworm-slim
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+ARG NODE_IMAGE=node:22-bookworm-slim
+FROM ${NODE_IMAGE} AS builder
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV DATABASE_URL="postgresql://postgres:postgres@localhost:5432/persona_seq?schema=public"
+RUN npx prisma generate
+RUN npm run build
+
+ARG NODE_IMAGE=node:22-bookworm-slim
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/docker/entrypoint.sh ./docker/entrypoint.sh
+COPY --from=builder /app/docker/seed.mjs ./docker/seed.mjs
+
+RUN chmod +x ./docker/entrypoint.sh \
+  && chown -R nextjs:nodejs /app
+
+USER nextjs
+
+EXPOSE 3000
+
+ENTRYPOINT ["./docker/entrypoint.sh"]

--- a/app/(app)/cases/[id]/page.tsx
+++ b/app/(app)/cases/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ProposalStatus } from "@prisma/client";
+import { GenerationStatus, ProposalStatus } from "@prisma/client";
 import { notFound } from "next/navigation";
 import {
   createRevisionFromFeedback,
@@ -6,6 +6,7 @@ import {
   markCanceledAction,
   sendCurrentRevision,
 } from "@/app/(app)/cases/actions";
+import { GenerationStatusPanel } from "@/components/generation-status-panel";
 import { ProposalEditor } from "@/components/proposal-editor";
 import { RevisionTimeline } from "@/components/revision-timeline";
 import { SimilarCasesPanel } from "@/components/similar-cases-panel";
@@ -36,10 +37,16 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
       (revision) => revision.revisionNumber === proposalCase.currentRevisionNumber,
     ) ?? proposalCase.revisions.at(-1);
 
-  const similarCases = await findSimilarAcceptedCases({
-    originalRequestText: proposalCase.originalRequestText,
-    requirementSummary: proposalCase.requirementSummary,
-  });
+  const initialDraftWorkflowReady =
+    proposalCase.generationStatus === GenerationStatus.SUCCEEDED ||
+    proposalCase.status !== ProposalStatus.DRAFTING ||
+    proposalCase.revisions.length > 0;
+  const similarCases = initialDraftWorkflowReady
+    ? await findSimilarAcceptedCases({
+        originalRequestText: proposalCase.originalRequestText,
+        requirementSummary: proposalCase.requirementSummary,
+      })
+    : [];
   const canSendCurrentRevision = proposalCase.status === ProposalStatus.READY_TO_SEND;
   const canProcessCustomerFeedback =
     proposalCase.status === ProposalStatus.WAITING_CUSTOMER_FEEDBACK;
@@ -70,6 +77,14 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
             <CardTitle>客户上下文</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            {!initialDraftWorkflowReady ? (
+              <GenerationStatusPanel
+                proposalCaseId={proposalCase.id}
+                generationStatus={proposalCase.generationStatus}
+                generationError={proposalCase.generationError}
+              />
+            ) : null}
+
             <section className="space-y-2">
               <h2 className="text-sm font-medium text-slate-200">客户原始需求</h2>
               <p className="whitespace-pre-wrap rounded-md border border-slate-800 bg-slate-900/70 p-3 text-sm leading-6 text-slate-300">
@@ -105,7 +120,7 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
             <CardTitle>分析师方案确认</CardTitle>
           </CardHeader>
           <CardContent>
-            {currentRevision ? (
+            {initialDraftWorkflowReady && currentRevision ? (
               <ProposalEditor
                 proposalCaseId={proposalCase.id}
                 revisionId={currentRevision.id}
@@ -115,7 +130,9 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
               />
             ) : (
               <p className="rounded-md border border-dashed border-slate-700 bg-slate-900/60 p-4 text-sm text-slate-400">
-                当前没有可编辑的修订草稿。
+                {initialDraftWorkflowReady
+                  ? "当前没有可编辑的修订草稿。"
+                  : "草稿尚未生成完成，生成结束后可在此编辑确认。"}
               </p>
             )}
           </CardContent>
@@ -124,7 +141,7 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
         <SimilarCasesPanel cases={similarCases} />
       </div>
 
-      {currentRevision?.analystConfirmedText?.trim() ? (
+      {initialDraftWorkflowReady && currentRevision?.analystConfirmedText?.trim() ? (
         <Card className="border-slate-700 bg-slate-950/70 text-slate-100">
           <CardHeader>
             <CardTitle>PM 客户反馈操作</CardTitle>

--- a/app/(app)/cases/actions.ts
+++ b/app/(app)/cases/actions.ts
@@ -3,10 +3,11 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
-  generateInitialProposalDraft,
   generateRevisionProposalDraft,
 } from "@/lib/ai/generate-proposal";
-import { MockProposalAiProvider } from "@/lib/ai/mock-provider";
+import { errorMessage } from "@/lib/ai/generation-errors";
+import { getProposalAiProvider } from "@/lib/ai/get-proposal-ai-provider";
+import { runInitialDraftGeneration } from "@/lib/ai/run-initial-generation";
 import { getCurrentUser } from "@/lib/auth/current-user";
 import {
   assertCaseReadyForFeedbackRevision,
@@ -16,7 +17,6 @@ import {
   markCustomerAccepted,
   markCustomerCanceled,
   markSentToCustomer,
-  updateCaseAfterInitialGeneration,
 } from "@/lib/db/proposal-repository";
 import { prisma } from "@/lib/db/prisma";
 import {
@@ -35,17 +35,15 @@ export async function createCaseAndGenerateDraft(formData: FormData) {
     ...input,
     pmUserId: currentUser.id,
   });
-  const provider = new MockProposalAiProvider();
-  const draft = await generateInitialProposalDraft(provider, {
-    originalRequestText: input.originalRequestText,
-  });
 
-  await updateCaseAfterInitialGeneration({
+  void runInitialDraftGeneration({
     proposalCaseId: proposalCase.id,
-    requirementSummary: draft.requirementSummary,
-    missingInformation: draft.missingInformation,
-    aiDraft: draft.proposalDraft,
     actorUserId: currentUser.id,
+  }).catch((error: unknown) => {
+    console.error(
+      "Initial generation background task failed:",
+      errorMessage(error, "background generation failed"),
+    );
   });
 
   revalidatePath("/cases");
@@ -129,7 +127,7 @@ export async function createRevisionFromFeedback(formData: FormData) {
   assertCaseReadyForFeedbackRevision(proposalCase, previousRevision);
   const previousConfirmedProposal = previousRevision.analystConfirmedText as string;
 
-  const provider = new MockProposalAiProvider();
+  const provider = getProposalAiProvider();
   const draft = await generateRevisionProposalDraft(provider, {
     originalRequestText: proposalCase.originalRequestText,
     previousConfirmedProposal,

--- a/app/(app)/cases/new/page.tsx
+++ b/app/(app)/cases/new/page.tsx
@@ -85,8 +85,8 @@ export default function NewCasePage() {
 
             <div className="flex flex-wrap items-center justify-end gap-3">
               <SubmitButton
-                idleText="创建并生成草稿"
-                pendingText="生成中..."
+                idleText="创建案例"
+                pendingText="创建中..."
                 className="bg-cyan-500 text-slate-950 hover:bg-cyan-400 disabled:cursor-not-allowed disabled:opacity-70"
               />
             </div>

--- a/app/api/cases/[id]/generate/route.ts
+++ b/app/api/cases/[id]/generate/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { errorMessage } from "@/lib/ai/generation-errors";
+import { runInitialDraftGeneration } from "@/lib/ai/run-initial-generation";
+import { getCurrentUser } from "@/lib/auth/current-user";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const currentUser = await getCurrentUser();
+
+  try {
+    const result = await runInitialDraftGeneration({
+      proposalCaseId: id,
+      actorUserId: currentUser.id,
+    });
+    if (result.status === "running") {
+      return NextResponse.json(result, { status: 202 });
+    }
+    if (result.status === "failed") {
+      return NextResponse.json(result, { status: 500 });
+    }
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    const message = errorMessage(error, "Failed to start");
+    if (message === "Proposal case was not found") {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: message }, { status: 409 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,5 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <main className="container flex min-h-screen items-center justify-center py-10">
-      <Card className="w-full max-w-2xl">
-        <CardHeader>
-          <Badge className="w-fit">MVP</Badge>
-          <CardTitle className="mt-3 text-3xl">Proposal Platform</CardTitle>
-          <CardDescription>Next.js App Router scaffold with Tailwind CSS and shadcn/ui.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button>Get started</Button>
-        </CardContent>
-      </Card>
-    </main>
-  );
+  redirect("/cases");
 }

--- a/components/generation-status-panel.tsx
+++ b/components/generation-status-panel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { Loader2, RefreshCcw } from "lucide-react";
+import { GenerationStatus } from "@prisma/client";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+type GenerationStatusPanelProps = {
+  proposalCaseId: string;
+  generationStatus: GenerationStatus;
+  generationError: string | null;
+};
+
+const POLL_INTERVAL_MS = 4000;
+
+export function GenerationStatusPanel({
+  proposalCaseId,
+  generationStatus,
+  generationError,
+}: GenerationStatusPanelProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [localError, setLocalError] = useState<string | null>(null);
+  const startedRef = useRef(false);
+
+  const refreshPage = useCallback(() => {
+    startTransition(() => {
+      router.refresh();
+    });
+  }, [router]);
+
+  const triggerGeneration = useCallback(async () => {
+    try {
+      setLocalError(null);
+      const response = await fetch(`/api/cases/${proposalCaseId}/generate`, {
+        method: "POST",
+      });
+      if (!response.ok && response.status !== 202) {
+        const payload = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        setLocalError(payload?.error ?? "触发生成失败，请重试。");
+      }
+    } catch {
+      setLocalError("网络异常，未能触发生成。");
+    } finally {
+      refreshPage();
+    }
+  }, [proposalCaseId, refreshPage]);
+
+  useEffect(() => {
+    if (generationStatus !== GenerationStatus.PENDING || startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    void triggerGeneration();
+  }, [generationStatus, triggerGeneration]);
+
+  useEffect(() => {
+    if (
+      generationStatus !== GenerationStatus.PENDING &&
+      generationStatus !== GenerationStatus.RUNNING
+    ) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      refreshPage();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [generationStatus, refreshPage]);
+
+  const canRetry = generationStatus === GenerationStatus.FAILED && !isPending;
+
+  return (
+    <div className="space-y-3 rounded-lg border border-slate-700 bg-slate-900/60 p-4">
+      <div className="flex items-start gap-3">
+        {(generationStatus === GenerationStatus.PENDING ||
+          generationStatus === GenerationStatus.RUNNING) && (
+          <Loader2 className="mt-0.5 size-4 animate-spin text-cyan-300" aria-hidden />
+        )}
+        <div className="space-y-1 text-sm">
+          <p className="font-medium text-slate-100">
+            {generationStatus === GenerationStatus.FAILED
+              ? "AI 生成失败"
+              : "AI 正在生成草稿，通常需要 1-2 分钟"}
+          </p>
+          <p className="text-slate-300">
+            {generationStatus === GenerationStatus.FAILED
+              ? generationError?.trim() || "请检查 AI 配置后重试。"
+              : "你可以离开此页面，系统会持续生成。"}
+          </p>
+          {localError ? <p className="text-rose-300">{localError}</p> : null}
+        </div>
+      </div>
+
+      {generationStatus === GenerationStatus.FAILED ? (
+        <Button
+          type="button"
+          onClick={() => void triggerGeneration()}
+          disabled={!canRetry}
+          className="border border-slate-600 bg-slate-800 text-slate-100 hover:bg-slate-700"
+        >
+          <RefreshCcw className="mr-2 size-4" aria-hidden />
+          重新生成
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/generation-status-panel.tsx
+++ b/components/generation-status-panel.tsx
@@ -2,17 +2,20 @@
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { Loader2, RefreshCcw } from "lucide-react";
-import { GenerationStatus } from "@prisma/client";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
+/** Mirrors Prisma `GenerationStatus` — do not import `@prisma/client` in Client Components (breaks browser bundle). */
+type GenerationStatusValue = "PENDING" | "RUNNING" | "SUCCEEDED" | "FAILED";
+
 type GenerationStatusPanelProps = {
   proposalCaseId: string;
-  generationStatus: GenerationStatus;
+  generationStatus: GenerationStatusValue;
   generationError: string | null;
 };
 
-const POLL_INTERVAL_MS = 4000;
+/** 低频轮询，避免与同页的 Server Action（如分析师确认提交）争抢 router.refresh */
+const POLL_INTERVAL_MS = 12_000;
 
 export function GenerationStatusPanel({
   proposalCaseId,
@@ -50,7 +53,7 @@ export function GenerationStatusPanel({
   }, [proposalCaseId, refreshPage]);
 
   useEffect(() => {
-    if (generationStatus !== GenerationStatus.PENDING || startedRef.current) {
+    if (generationStatus !== "PENDING" || startedRef.current) {
       return;
     }
     startedRef.current = true;
@@ -58,39 +61,42 @@ export function GenerationStatusPanel({
   }, [generationStatus, triggerGeneration]);
 
   useEffect(() => {
-    if (
-      generationStatus !== GenerationStatus.PENDING &&
-      generationStatus !== GenerationStatus.RUNNING
-    ) {
+    if (generationStatus !== "PENDING" && generationStatus !== "RUNNING") {
       return;
     }
 
-    const timer = window.setInterval(() => {
+    const tick = () => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+        return;
+      }
       refreshPage();
-    }, POLL_INTERVAL_MS);
+    };
+
+    const timer = window.setInterval(tick, POLL_INTERVAL_MS);
+    document.addEventListener("visibilitychange", tick);
 
     return () => {
       window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", tick);
     };
   }, [generationStatus, refreshPage]);
 
-  const canRetry = generationStatus === GenerationStatus.FAILED && !isPending;
+  const canRetry = generationStatus === "FAILED" && !isPending;
 
   return (
     <div className="space-y-3 rounded-lg border border-slate-700 bg-slate-900/60 p-4">
       <div className="flex items-start gap-3">
-        {(generationStatus === GenerationStatus.PENDING ||
-          generationStatus === GenerationStatus.RUNNING) && (
+        {(generationStatus === "PENDING" || generationStatus === "RUNNING") && (
           <Loader2 className="mt-0.5 size-4 animate-spin text-cyan-300" aria-hidden />
         )}
         <div className="space-y-1 text-sm">
           <p className="font-medium text-slate-100">
-            {generationStatus === GenerationStatus.FAILED
+            {generationStatus === "FAILED"
               ? "AI 生成失败"
               : "AI 正在生成草稿，通常需要 1-2 分钟"}
           </p>
           <p className="text-slate-300">
-            {generationStatus === GenerationStatus.FAILED
+            {generationStatus === "FAILED"
               ? generationError?.trim() || "请检查 AI 配置后重试。"
               : "你可以离开此页面，系统会持续生成。"}
           </p>
@@ -98,7 +104,7 @@ export function GenerationStatusPanel({
         </div>
       </div>
 
-      {generationStatus === GenerationStatus.FAILED ? (
+      {generationStatus === "FAILED" ? (
         <Button
           type="button"
           onClick={() => void triggerGeneration()}

--- a/components/proposal-editor.tsx
+++ b/components/proposal-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useState } from "react";
 import { Loader2 } from "lucide-react";
-import { useFormStatus } from "react-dom";
 import { confirmCurrentRevision } from "@/app/(app)/cases/actions";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -13,35 +13,25 @@ type ProposalEditorProps = {
   initialText: string;
 };
 
-function ConfirmSubmitButton() {
-  const { pending } = useFormStatus();
-
-  return (
-    <Button
-      type="submit"
-      disabled={pending}
-      aria-disabled={pending}
-      className="bg-cyan-500 text-slate-950 hover:bg-cyan-400 disabled:opacity-70"
-    >
-      {pending ? (
-        <>
-          <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
-          保存确认中...
-        </>
-      ) : (
-        "确认当前方案"
-      )}
-    </Button>
-  );
-}
-
 export function ProposalEditor({
   proposalCaseId,
   revisionId,
   initialText,
 }: ProposalEditorProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   return (
-    <form action={confirmCurrentRevision} className="space-y-4">
+    <form
+      className="space-y-4"
+      action={async (formData) => {
+        setIsSubmitting(true);
+        try {
+          await confirmCurrentRevision(formData);
+        } finally {
+          setIsSubmitting(false);
+        }
+      }}
+    >
       <input type="hidden" name="proposalCaseId" value={proposalCaseId} />
       <input type="hidden" name="revisionId" value={revisionId} />
 
@@ -59,7 +49,21 @@ export function ProposalEditor({
       </div>
 
       <div className="flex items-center justify-end">
-        <ConfirmSubmitButton />
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          aria-disabled={isSubmitting}
+          className="bg-cyan-500 text-slate-950 hover:bg-cyan-400 disabled:opacity-70"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+              保存确认中...
+            </>
+          ) : (
+            "确认当前方案"
+          )}
+        </Button>
       </div>
     </form>
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: mirror.gcr.io/library/postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: persona_seq
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d persona_seq"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NODE_IMAGE: mirror.gcr.io/library/node:22-bookworm-slim
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/persona_seq?schema=public
+      NODE_ENV: production
+      HOSTNAME: 0.0.0.0
+      PORT: "3000"
+      NEXTAUTH_SECRET: local-docker-secret-change-me
+      NEXTAUTH_URL: http://localhost:3000
+      # mock | openai（openai 需设置 AI_API_KEY，可选 AI_BASE_URL / AI_MODEL）
+      AI_PROVIDER: ${AI_PROVIDER:-mock}
+      AI_API_KEY: ${AI_API_KEY:-}
+      AI_BASE_URL: ${AI_BASE_URL:-}
+      AI_MODEL: ${AI_MODEL:-}
+      AI_TIMEOUT_MS: ${AI_TIMEOUT_MS:-120000}
+      AI_MAX_TOKENS: ${AI_MAX_TOKENS:-2200}
+      AI_TEMPERATURE: ${AI_TEMPERATURE:-0.35}
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres_data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+PRISMA_BIN="./node_modules/.bin/prisma"
+
+echo "Waiting for database..."
+until "$PRISMA_BIN" db execute --schema prisma/schema.prisma --stdin <<'SQL' >/dev/null 2>&1
+select 1;
+SQL
+do
+  sleep 1
+done
+
+echo "Applying schema (db push)..."
+"$PRISMA_BIN" db push --schema prisma/schema.prisma --accept-data-loss
+
+echo "Seeding minimal users..."
+node ./docker/seed.mjs
+
+echo "Starting Next.js..."
+exec node server.js

--- a/docker/seed.mjs
+++ b/docker/seed.mjs
@@ -1,0 +1,57 @@
+import {
+  GenerationStatus,
+  PrismaClient,
+  ProposalStatus,
+  UserRole,
+} from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.user.upsert({
+    where: { id: "seed-pm-user" },
+    update: {},
+    create: {
+      id: "seed-pm-user",
+      email: "pm@example.com",
+      name: "PM User",
+      role: UserRole.PM,
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { id: "seed-analyst-user" },
+    update: {},
+    create: {
+      id: "seed-analyst-user",
+      email: "analyst@example.com",
+      name: "Analyst User",
+      role: UserRole.ANALYST,
+    },
+  });
+
+  await prisma.proposalCase.updateMany({
+    where: {
+      generationStatus: GenerationStatus.PENDING,
+      OR: [
+        { status: { not: ProposalStatus.DRAFTING } },
+        { revisions: { some: {} } },
+      ],
+    },
+    data: {
+      generationStatus: GenerationStatus.SUCCEEDED,
+      generationError: null,
+      generationFinishedAt: new Date(),
+    },
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error(error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/docs/superpowers/specs/2026-04-27-personalized-bioinformatics-proposal-platform-design.md
+++ b/docs/superpowers/specs/2026-04-27-personalized-bioinformatics-proposal-platform-design.md
@@ -389,4 +389,3 @@ The MVP is successful if:
 5. Template library for standard bioinformatics proposal types.
 6. Multiple AI model support, allowing several models or prompt strategies to generate proposal variants in parallel for analyst comparison and selection.
 7. Dashboards for turnaround time, revision count, analyst workload, proposal acceptance rate, model usage, and draft selection outcomes.
-

--- a/lib/ai/generation-errors.ts
+++ b/lib/ai/generation-errors.ts
@@ -1,0 +1,14 @@
+export function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function sanitizeGenerationError(error: unknown) {
+  const rawMessage =
+    error instanceof Error ? error.message : "Initial generation failed";
+  const compactMessage = rawMessage.replace(/\s+/g, " ").trim();
+
+  if (compactMessage.startsWith("AI 请求失败")) {
+    return compactMessage.slice(0, 300);
+  }
+  return "AI 生成失败，请稍后重试。";
+}

--- a/lib/ai/get-proposal-ai-provider.ts
+++ b/lib/ai/get-proposal-ai-provider.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { MockProposalAiProvider } from "@/lib/ai/mock-provider";
+import { OpenAiChatProposalAiProvider } from "@/lib/ai/openai-chat-provider";
+import type { ProposalAiProvider } from "@/lib/ai/types";
+
+const DEFAULT_BASE = "https://api.openai.com/v1";
+const DEFAULT_MODEL = "gpt-4o-mini";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_TOKENS = 2200;
+const DEFAULT_TEMPERATURE = 0.35;
+
+function parseIntegerOrDefault(raw: string | undefined, defaultValue: number) {
+  if (!raw) return defaultValue;
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) return defaultValue;
+
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}
+
+function parseTemperatureOrDefault(raw: string | undefined, defaultValue: number) {
+  if (!raw) return defaultValue;
+  const normalized = raw.trim();
+  if (!/^\d+(\.\d+)?$/.test(normalized)) return defaultValue;
+
+  const parsed = Number.parseFloat(normalized);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.min(Math.max(parsed, 0), 1);
+}
+
+function normalizeBaseUrl(raw: string | undefined): string {
+  const trimmed = (raw ?? DEFAULT_BASE).trim().replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : DEFAULT_BASE;
+}
+
+/**
+ * 根据环境变量选择 AI 实现。
+ *
+ * - `AI_PROVIDER=mock`：本地占位文案，不调外部接口。
+ * - `AI_PROVIDER=openai`：调用 OpenAI 兼容的 `POST {base}/chat/completions`（Bearer）。
+ */
+export function getProposalAiProvider(): ProposalAiProvider {
+  const mode = (process.env.AI_PROVIDER ?? "mock").trim().toLowerCase();
+
+  if (mode === "mock" || mode === "") {
+    return new MockProposalAiProvider();
+  }
+
+  if (mode === "openai") {
+    const apiKey = (process.env.AI_API_KEY ?? "").trim();
+    if (!apiKey) {
+      throw new Error(
+        'AI_PROVIDER=openai 时必须设置 AI_API_KEY（或改用 AI_PROVIDER=mock）',
+      );
+    }
+
+    const baseUrl = normalizeBaseUrl(process.env.AI_BASE_URL);
+    const model = (process.env.AI_MODEL ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+    const timeoutMs = parseIntegerOrDefault(
+      process.env.AI_TIMEOUT_MS,
+      DEFAULT_TIMEOUT_MS,
+    );
+    const maxTokens = parseIntegerOrDefault(
+      process.env.AI_MAX_TOKENS,
+      DEFAULT_MAX_TOKENS,
+    );
+    const temperature = parseTemperatureOrDefault(
+      process.env.AI_TEMPERATURE,
+      DEFAULT_TEMPERATURE,
+    );
+
+    return new OpenAiChatProposalAiProvider({
+      apiKey,
+      baseUrl,
+      model,
+      timeoutMs,
+      maxTokens,
+      temperature,
+    });
+  }
+
+  throw new Error(
+    `未知的 AI_PROVIDER="${process.env.AI_PROVIDER}"，请使用 mock 或 openai`,
+  );
+}

--- a/lib/ai/openai-chat-provider.ts
+++ b/lib/ai/openai-chat-provider.ts
@@ -1,0 +1,64 @@
+import type { ProposalAiProvider } from "./types";
+
+type OpenAiChatProviderOptions = {
+  apiKey: string;
+  /** 不含尾斜杠，例如 https://api.openai.com/v1 或兼容服务的 /v1 根路径 */
+  baseUrl: string;
+  model: string;
+  /** 毫秒 */
+  timeoutMs: number;
+  maxTokens: number;
+  temperature: number;
+};
+
+type ChatCompletionsResponse = {
+  choices?: Array<{ message?: { content?: string | null } }>;
+  error?: { message?: string };
+};
+
+export class OpenAiChatProposalAiProvider implements ProposalAiProvider {
+  private readonly options: OpenAiChatProviderOptions;
+
+  constructor(options: OpenAiChatProviderOptions) {
+    this.options = options;
+  }
+
+  async generateText(prompt: string): Promise<string> {
+    const url = `${this.options.baseUrl}/chat/completions`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.options.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.options.model,
+          messages: [{ role: "user", content: prompt }],
+          max_tokens: this.options.maxTokens,
+          temperature: this.options.temperature,
+        }),
+      });
+
+      const body = (await res.json()) as ChatCompletionsResponse;
+
+      if (!res.ok) {
+        const msg = body.error?.message ?? res.statusText;
+        throw new Error(`AI 请求失败 (${res.status}): ${msg}`);
+      }
+
+      const text = body.choices?.[0]?.message?.content;
+      if (typeof text !== "string" || !text.trim()) {
+        throw new Error("AI 返回内容为空");
+      }
+
+      return text;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -24,6 +24,7 @@ export function buildInitialProposalPrompt(input: InitialProposalInput) {
     proposalStructure,
     "",
     "要求: 不要编造客户没有提供的样本数量、物种、测序类型或交付周期；不确定的信息放入需要客户补充确认的问题。",
+    "篇幅要求: 生成可供分析师二次编辑的简洁初稿，尽量控制在 1200-1800 中文字。",
   ].join("\n");
 }
 
@@ -46,5 +47,6 @@ export function buildRevisionProposalPrompt(input: RevisionProposalInput) {
     "C. 仍需客户确认的问题或风险",
     "",
     "要求: 保留上一版仍然有效的内容；明确回应客户反馈；不要让 AI 草稿看起来像已经经过人工最终确认。",
+    "篇幅要求: 输出聚焦改动点的简洁修订稿，避免冗长重复，便于分析师快速确认。",
   ].join("\n");
 }

--- a/lib/ai/run-initial-generation.ts
+++ b/lib/ai/run-initial-generation.ts
@@ -1,0 +1,67 @@
+import "server-only";
+
+import { revalidatePath } from "next/cache";
+import { generateInitialProposalDraft } from "@/lib/ai/generate-proposal";
+import { sanitizeGenerationError } from "@/lib/ai/generation-errors";
+import { getProposalAiProvider } from "@/lib/ai/get-proposal-ai-provider";
+import {
+  markInitialGenerationFailed,
+  startInitialDraftGeneration,
+  updateCaseAfterInitialGeneration,
+} from "@/lib/db/proposal-repository";
+
+type RunInitialGenerationInput = {
+  proposalCaseId: string;
+  actorUserId: string;
+};
+
+type RunInitialGenerationResult =
+  | { status: "running" }
+  | { status: "succeeded" }
+  | { status: "failed"; error: string };
+
+export async function runInitialDraftGeneration(
+  input: RunInitialGenerationInput,
+): Promise<RunInitialGenerationResult> {
+  const started = await startInitialDraftGeneration(input);
+
+  if (started.kind === "running") {
+    return { status: "running" };
+  }
+  if (started.kind === "noop") {
+    return { status: "succeeded" };
+  }
+
+  try {
+    const provider = getProposalAiProvider();
+    const draft = await generateInitialProposalDraft(provider, {
+      originalRequestText: started.originalRequestText,
+    });
+
+    await updateCaseAfterInitialGeneration({
+      proposalCaseId: input.proposalCaseId,
+      requirementSummary: draft.requirementSummary,
+      missingInformation: draft.missingInformation,
+      aiDraft: draft.proposalDraft,
+      actorUserId: input.actorUserId,
+    });
+
+    revalidatePath("/cases");
+    revalidatePath(`/cases/${input.proposalCaseId}`);
+
+    return { status: "succeeded" };
+  } catch (error) {
+    const errorMessage = sanitizeGenerationError(error);
+
+    await markInitialGenerationFailed({
+      proposalCaseId: input.proposalCaseId,
+      actorUserId: input.actorUserId,
+      errorMessage,
+    });
+
+    revalidatePath("/cases");
+    revalidatePath(`/cases/${input.proposalCaseId}`);
+
+    return { status: "failed", error: errorMessage };
+  }
+}

--- a/lib/db/proposal-repository.ts
+++ b/lib/db/proposal-repository.ts
@@ -1,5 +1,6 @@
 import {
   FinalOutcome,
+  GenerationStatus,
   ProposalStatus,
   type ProposalCase,
   type Revision,
@@ -199,6 +200,7 @@ export async function createProposalCase(input: CreateProposalCaseInput) {
         pmUserId: input.pmUserId,
         analystUserId: input.analystUserId ?? null,
         status: ProposalStatus.DRAFTING,
+        generationStatus: GenerationStatus.PENDING,
       },
     });
 
@@ -215,6 +217,128 @@ export async function createProposalCase(input: CreateProposalCaseInput) {
   });
 }
 
+type StartInitialGenerationInput = {
+  proposalCaseId: string;
+  actorUserId: string;
+};
+
+type InitialGenerationStartResult =
+  | {
+      kind: "started";
+      proposalCaseId: string;
+      originalRequestText: string;
+    }
+  | { kind: "running" }
+  | {
+      kind: "noop";
+      reason: "generation_already_succeeded" | "workflow_advanced";
+    };
+
+type FailInitialGenerationInput = {
+  proposalCaseId: string;
+  actorUserId: string;
+  errorMessage: string;
+};
+
+const STALE_RUNNING_GENERATION_MS = 5 * 60 * 1000;
+
+export function isStaleRunningGeneration(
+  generationStartedAt: Date | null,
+  now = new Date(),
+) {
+  if (!generationStartedAt) return true;
+  return now.getTime() - generationStartedAt.getTime() > STALE_RUNNING_GENERATION_MS;
+}
+
+export async function startInitialDraftGeneration(
+  input: StartInitialGenerationInput,
+): Promise<InitialGenerationStartResult> {
+  return prisma.$transaction(async (tx) => {
+    const now = new Date();
+    const proposalCase = await tx.proposalCase.findUnique({
+      where: { id: input.proposalCaseId },
+      select: {
+        id: true,
+        status: true,
+        generationStatus: true,
+        generationStartedAt: true,
+        originalRequestText: true,
+      },
+    });
+
+    if (!proposalCase) {
+      throw new Error("Proposal case was not found");
+    }
+    if (proposalCase.generationStatus === GenerationStatus.SUCCEEDED) {
+      return {
+        kind: "noop",
+        reason: "generation_already_succeeded",
+      };
+    }
+    if (
+      proposalCase.generationStatus === GenerationStatus.RUNNING &&
+      !isStaleRunningGeneration(proposalCase.generationStartedAt, now)
+    ) {
+      return { kind: "running" };
+    }
+    if (proposalCase.status !== ProposalStatus.DRAFTING) {
+      return { kind: "noop", reason: "workflow_advanced" };
+    }
+    if (
+      proposalCase.generationStatus !== GenerationStatus.PENDING &&
+      proposalCase.generationStatus !== GenerationStatus.FAILED &&
+      proposalCase.generationStatus !== GenerationStatus.RUNNING
+    ) {
+      throw new Error("Initial generation has already started");
+    }
+
+    const staleBefore = new Date(now.getTime() - STALE_RUNNING_GENERATION_MS);
+    const updateResult = await tx.proposalCase.updateMany({
+      where: {
+        id: input.proposalCaseId,
+        status: ProposalStatus.DRAFTING,
+        OR: [
+          { generationStatus: GenerationStatus.PENDING },
+          { generationStatus: GenerationStatus.FAILED },
+          {
+            generationStatus: GenerationStatus.RUNNING,
+            OR: [
+              { generationStartedAt: null },
+              { generationStartedAt: { lt: staleBefore } },
+            ],
+          },
+        ],
+      },
+      data: {
+        generationStatus: GenerationStatus.RUNNING,
+        generationError: null,
+        generationStartedAt: now,
+        generationFinishedAt: null,
+        generationAttemptCount: { increment: 1 },
+      },
+    });
+
+    if (updateResult.count !== 1) {
+      return { kind: "running" };
+    }
+
+    await tx.auditLog.create({
+      data: {
+        proposalCaseId: input.proposalCaseId,
+        actorUserId: input.actorUserId,
+        action: "start_initial_generation",
+        afterStatus: ProposalStatus.DRAFTING,
+      },
+    });
+
+    return {
+      kind: "started",
+      proposalCaseId: proposalCase.id,
+      originalRequestText: proposalCase.originalRequestText,
+    };
+  });
+}
+
 export async function updateCaseAfterInitialGeneration(
   input: UpdateCaseAfterInitialGenerationInput,
 ) {
@@ -224,6 +348,7 @@ export async function updateCaseAfterInitialGeneration(
       select: {
         id: true,
         status: true,
+        generationStatus: true,
         currentRevisionNumber: true,
         finalOutcome: true,
       },
@@ -238,6 +363,7 @@ export async function updateCaseAfterInitialGeneration(
       where: {
         id: input.proposalCaseId,
         status: ProposalStatus.DRAFTING,
+        generationStatus: GenerationStatus.RUNNING,
         currentRevisionNumber: 1,
         finalOutcome: null,
       },
@@ -245,6 +371,9 @@ export async function updateCaseAfterInitialGeneration(
         requirementSummary: input.requirementSummary,
         missingInformation: input.missingInformation,
         status: ProposalStatus.ANALYST_REVIEW,
+        generationStatus: GenerationStatus.SUCCEEDED,
+        generationError: null,
+        generationFinishedAt: new Date(),
       },
     });
 
@@ -273,6 +402,41 @@ export async function updateCaseAfterInitialGeneration(
 
     return tx.proposalCase.findUniqueOrThrow({
       where: { id: input.proposalCaseId },
+    });
+  });
+}
+
+export async function markInitialGenerationFailed(
+  input: FailInitialGenerationInput,
+) {
+  return prisma.$transaction(async (tx) => {
+    const updateResult = await tx.proposalCase.updateMany({
+      where: {
+        id: input.proposalCaseId,
+        status: ProposalStatus.DRAFTING,
+        generationStatus: GenerationStatus.RUNNING,
+      },
+      data: {
+        generationStatus: GenerationStatus.FAILED,
+        generationError: input.errorMessage,
+        generationFinishedAt: new Date(),
+      },
+    });
+
+    if (updateResult.count !== 1) {
+      return;
+    }
+
+    await tx.auditLog.create({
+      data: {
+        proposalCaseId: input.proposalCaseId,
+        actorUserId: input.actorUserId,
+        action: "initial_generation_failed",
+        afterStatus: ProposalStatus.DRAFTING,
+        metadata: {
+          message: input.errorMessage,
+        },
+      },
     });
   });
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  output: "standalone",
+};
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,13 @@ enum FinalOutcome {
   CANCELED @map("canceled")
 }
 
+enum GenerationStatus {
+  PENDING   @map("pending")
+  RUNNING   @map("running")
+  SUCCEEDED @map("succeeded")
+  FAILED    @map("failed")
+}
+
 model User {
   id        String   @id @default(cuid())
   name      String
@@ -49,6 +56,11 @@ model ProposalCase {
   requirementSummary    String?
   missingInformation    String?
   status                ProposalStatus @default(DRAFTING)
+  generationStatus      GenerationStatus @default(PENDING)
+  generationError       String?
+  generationAttemptCount Int             @default(0)
+  generationStartedAt   DateTime?
+  generationFinishedAt  DateTime?
   currentRevisionNumber Int            @default(1)
   finalOutcome          FinalOutcome?
   createdAt             DateTime       @default(now())

--- a/tests/ai/run-initial-generation.test.ts
+++ b/tests/ai/run-initial-generation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage, sanitizeGenerationError } from "@/lib/ai/generation-errors";
+
+describe("initial generation runner", () => {
+  it("keeps sanitized provider errors without leaking large payloads", () => {
+    const error = new Error(`AI 请求失败 (401): not authorized ${"x".repeat(500)}`);
+
+    const sanitized = sanitizeGenerationError(error);
+
+    expect(sanitized).toMatch(/^AI 请求失败 \(401\): not authorized/);
+    expect(sanitized.length).toBeLessThanOrEqual(300);
+  });
+
+  it("uses a generic message for unexpected errors", () => {
+    expect(sanitizeGenerationError(new Error("raw stack details"))).toBe(
+      "AI 生成失败，请稍后重试。",
+    );
+  });
+
+  it("formats unknown errors with a fallback", () => {
+    expect(errorMessage(123, "oops")).toBe("oops");
+    expect(errorMessage(new Error("x"), "oops")).toBe("x");
+  });
+});

--- a/tests/db/proposal-repository.test.ts
+++ b/tests/db/proposal-repository.test.ts
@@ -6,6 +6,7 @@ import {
   assertCaseReadyForInitialGeneration,
   assertCaseReadyToSend,
   assertCaseWaitingCustomerFeedback,
+  isStaleRunningGeneration,
   assertRevisionBelongsToCase,
   assertRevisionConfirmedBeforeSending,
   assertRevisionNotAlreadyConfirmed,
@@ -149,5 +150,17 @@ describe("proposal repository invariants", () => {
         createRevision({ revisionNumber: 1 }),
       ),
     ).toThrowError("Current revision mismatch while creating a new revision");
+  });
+
+  it("treats missing or old generation start times as stale", () => {
+    const now = new Date("2026-04-28T02:30:00.000Z");
+
+    expect(isStaleRunningGeneration(null, now)).toBe(true);
+    expect(
+      isStaleRunningGeneration(new Date("2026-04-28T02:20:00.000Z"), now),
+    ).toBe(true);
+    expect(
+      isStaleRunningGeneration(new Date("2026-04-28T02:28:00.000Z"), now),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Persist **initial draft generation status** on `ProposalCase` (pending/running/succeeded/failed) with retry-safe locking and stale `RUNNING` recovery.
- **Decouple** “create case” from long AI waits: redirect to detail, kick off generation server-side plus idempotent **`POST /api/cases/[id]/generate`**, polling UI with retry on failure.
- **OpenAI-compatible** provider (`AI_PROVIDER`, `AI_API_KEY`, `AI_BASE_URL`, `AI_MODEL`, `AI_MAX_TOKENS`, `AI_TEMPERATURE`, timeouts).
- **Docker**: `Dockerfile`, `docker-compose.yml`, Postgres + app, entrypoint `db push`/seed/minimal smoke.
- **`next.config.ts`**: `output: standalone` for container runtime.

## Test plan

- `npm test` && `npm run build`
- `docker compose up -d --build app` smoke (optional)

Made with [Cursor](https://cursor.com)