### PR TITLE
fix(cases): stabilize detail render after analyst confirm

### DIFF
--- a/app/(app)/cases/[id]/error.tsx
+++ b/app/(app)/cases/[id]/error.tsx
@@ -10,22 +10,22 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-type CasesErrorProps = {
+type CaseDetailErrorProps = {
   error: Error & { digest?: string };
   reset: () => void;
 };
 
-export default function CasesError({ error, reset }: CasesErrorProps) {
+export default function CaseDetailError({ error, reset }: CaseDetailErrorProps) {
   return (
     <section className="space-y-6">
       <Card className="border-rose-800/60 bg-slate-950/80 text-slate-100">
         <CardHeader className="space-y-2">
           <CardTitle className="flex items-center gap-2 text-rose-200">
             <AlertTriangle className="size-5" aria-hidden />
-            案例页面加载失败
+            案例详情加载失败
           </CardTitle>
           <CardDescription className="text-slate-300">
-            可能是数据库、网络或依赖异常，请检查环境后重试。
+            刷新或操作后页面未能重新渲染。若刚保存过方案，可重试；仍失败请查看终端或容器日志中的完整错误。
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/app/(app)/cases/[id]/page.tsx
+++ b/app/(app)/cases/[id]/page.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { getProposalCaseDetail } from "@/lib/db/proposal-repository";
-import { findSimilarAcceptedCases } from "@/lib/search/similar-cases";
+import { findSimilarAcceptedCasesSafely } from "@/lib/search/similar-cases";
 
 export const dynamic = "force-dynamic";
 
@@ -42,7 +42,7 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
     proposalCase.status !== ProposalStatus.DRAFTING ||
     proposalCase.revisions.length > 0;
   const similarCases = initialDraftWorkflowReady
-    ? await findSimilarAcceptedCases({
+    ? await findSimilarAcceptedCasesSafely({
         originalRequestText: proposalCase.originalRequestText,
         requirementSummary: proposalCase.requirementSummary,
       })

--- a/app/(app)/cases/actions.ts
+++ b/app/(app)/cases/actions.ts
@@ -58,7 +58,8 @@ export async function confirmCurrentRevision(formData: FormData) {
     ...input,
     actorUserId: currentUser.id,
   });
-  revalidatePath(`/cases/${input.proposalCaseId}`);
+  // Full navigation clears RSC/cache for this segment; revalidate alone can leave stale client state after mutate.
+  redirect(`/cases/${input.proposalCaseId}`);
 }
 
 export async function sendCurrentRevision(formData: FormData) {

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -52,5 +52,14 @@ type StatusBadgeProps = {
 export function StatusBadge({ status }: StatusBadgeProps) {
   const config = STATUS_CONFIG[status];
 
-  return <Badge className={config.className}>{config.label}</Badge>;
+  return (
+    <Badge
+      className={
+        config?.className ??
+        "border-slate-600 bg-slate-800/90 text-slate-200 ring-1 ring-inset ring-slate-500/40"
+      }
+    >
+      {config?.label ?? String(status)}
+    </Badge>
+  );
 }

--- a/lib/search/similar-cases.ts
+++ b/lib/search/similar-cases.ts
@@ -138,3 +138,17 @@ export async function findSimilarAcceptedCases(input: {
     };
   });
 }
+
+/** Never rejects — similar cases are ancillary; failures should not break case detail SSR. */
+export async function findSimilarAcceptedCasesSafely(input: {
+  originalRequestText: string;
+  requirementSummary: string | null;
+  limit?: number;
+}) {
+  try {
+    return await findSimilarAcceptedCases(input);
+  } catch (error: unknown) {
+    console.error("findSimilarAcceptedCases:", error);
+    return [];
+  }
+}

--- a/tests/search/similar-cases.test.ts
+++ b/tests/search/similar-cases.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/db/prisma", () => ({
 import {
   buildSimilarCaseSearchText,
   findSimilarAcceptedCases,
+  findSimilarAcceptedCasesSafely,
   extractSimilarCaseSearchTerms,
   normalizeSearchTerm,
 } from "@/lib/search/similar-cases";
@@ -163,5 +164,19 @@ describe("similar case search", () => {
     });
 
     expect(results[0]?.matchedReason).toBe("Matched accepted historical case");
+  });
+
+  it("safely returns empty array when the query fails", async () => {
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    findManyMock.mockRejectedValueOnce(new Error("database unavailable"));
+    try {
+      const results = await findSimilarAcceptedCasesSafely({
+        originalRequestText: "alpha beta",
+        requirementSummary: null,
+      });
+      expect(results).toEqual([]);
+    } finally {
+      stderr.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
### Summary

- Redirect after confirmRevision so the case detail performs a full navigation refresh instead of relying on `revalidatePath` alone.
- Wrap similar-case lookup in `findSimilarAcceptedCasesSafely` so DB/query failures do not break SSR.
- Add `app/(app)/cases/[id]/error.tsx` with detail-specific messaging; broaden parent `cases/error.tsx` copy.
- Defensive fallback in `StatusBadge`.

### Test plan

- [ ] Confirm analyst flow on `/cases/[id]` after save succeeds without error boundary.
- [ ] `npm test` / `npm run build` pass (verified locally).