### PR TITLE
fix: support markdown-bold headings and code fences in title/tag extraction

### DIFF
--- a/lib/ai/generate-proposal.ts
+++ b/lib/ai/generate-proposal.ts
@@ -13,7 +13,7 @@ export async function generateInitialProposalDraft(
 ): Promise<ProposalDraftResult> {
   const text = await provider.generateText(buildInitialProposalPrompt(input));
 
-  const suggestedTitle = extractTitle(text);
+  const suggestedTitle = extractSectionBody(text, "D.");
   return {
     requirementSummary:
       extractSection(text, "A.") ??
@@ -21,7 +21,7 @@ export async function generateInitialProposalDraft(
     missingInformation:
       extractSection(text, "B.") ?? "AI 未识别出缺失信息。",
     proposalDraft: extractSection(text, "C.") ?? text,
-    suggestedTitle: suggestedTitle ?? undefined,
+    suggestedTitle: suggestedTitle || undefined,
     tags: parseTags(text),
   };
 }
@@ -32,7 +32,7 @@ export async function generateRevisionProposalDraft(
 ): Promise<ProposalDraftResult> {
   const text = await provider.generateText(buildRevisionProposalPrompt(input));
 
-  const suggestedTitle = extractTitle(text);
+  const suggestedTitle = extractSectionBody(text, "D.");
 
   return {
     requirementSummary: "修订轮次沿用原始需求摘要。",
@@ -66,16 +66,12 @@ function extractSection(text: string, marker: string) {
   return text.slice(current.index, endExclusive).trim();
 }
 
-function extractTitle(text: string): string | null {
-  const section = extractSection(text, "D.");
+/** Like extractSection but strips the heading line, returning only the body. */
+function extractSectionBody(text: string, marker: string): string | null {
+  const section = extractSection(text, marker);
   if (!section) return null;
-
-  const lines = section.split("\n");
-  if (lines.length > 1) {
-    const body = lines.slice(1).join("\n").trim();
-    if (body) return body;
-  }
-  return lines[0].replace(/^D\.\s*/, "").trim() || null;
+  const newlineIndex = section.indexOf("\n");
+  return newlineIndex === -1 ? "" : section.slice(newlineIndex + 1).trim();
 }
 
 export function parseTags(text: string): ProposalDraftResult["tags"] {

--- a/lib/ai/generate-proposal.ts
+++ b/lib/ai/generate-proposal.ts
@@ -46,7 +46,8 @@ export async function generateRevisionProposalDraft(
 }
 
 function extractSection(text: string, marker: string) {
-  const headingRegex = /^\s*(A\.|B\.|C\.|D\.|E\.)/gm;
+  // Support markdown bold headings like "**D. 建议标题**"
+  const headingRegex = /^\s*(?:\*\*)?\s*(A\.|B\.|C\.|D\.|E\.)/gm;
   const headings = [...text.matchAll(headingRegex)].map((match) => ({
     marker: match[1],
     index: match.index ?? 0,
@@ -77,16 +78,18 @@ function extractSectionBody(text: string, marker: string): string | null {
 export function parseTags(text: string): ProposalDraftResult["tags"] {
   const section = extractSection(text, "E.");
   if (section) {
+    // Strip markdown code fences (```json / ```) so JSON.parse succeeds
+    const cleaned = section.replace(/```(?:json)?\n?/g, "");
     try {
-      const jsonStart = section.indexOf("{");
+      const jsonStart = cleaned.indexOf("{");
       if (jsonStart !== -1) {
-        const parsed = JSON.parse(section.slice(jsonStart));
+        const parsed = JSON.parse(cleaned.slice(jsonStart));
         return CaseTagsSchema.parse(parsed);
       }
     } catch {
     }
 
-    return parseTagsFromJson(section);
+    return parseTagsFromJson(cleaned);
   }
 
   return parseTagsFromJson(text);

--- a/tests/ai/generate-proposal.test.ts
+++ b/tests/ai/generate-proposal.test.ts
@@ -179,6 +179,49 @@ describe("proposal generation parsing", () => {
     expect(result.proposalDraft).toContain("共表达");
   });
 
+  it("parses title and tags from markdown-bold headings", async () => {
+    const result = await generateInitialProposalDraft(
+      providerReturning(
+        [
+          "A. 需求摘要",
+          "20K芯片ROH近交分析。",
+          "",
+          "C. 方案草稿",
+          "1. 客户需求理解",
+          "需要分析ROH。",
+          "",
+          "**D. 建议标题**",
+          "20K芯片ROH近交分析",
+          "",
+          "**E. 案例标签**",
+          "```json",
+          JSON.stringify({
+            productLine: "液相芯片捕获测序",
+            organism: null,
+            application: null,
+            analysisDepth: "个性化定制分析",
+            sampleTypes: [],
+            platforms: [],
+            keywordTags: ["ROH", "FROH", "近交系数", "液相芯片", "连续性纯合片段"],
+          }),
+          "```",
+        ].join("\n"),
+      ),
+      { originalRequestText: "20K芯片ROH近交分析" },
+    );
+
+    expect(result.suggestedTitle).toBe("20K芯片ROH近交分析");
+    expect(result.tags).toBeDefined();
+    expect(result.tags!.productLine).toBe("液相芯片捕获测序");
+    expect(result.tags!.keywordTags).toEqual([
+      "ROH",
+      "FROH",
+      "近交系数",
+      "液相芯片",
+      "连续性纯合片段",
+    ]);
+  });
+
   it("revision draft returns undefined title and tags when sections are absent", async () => {
     const result = await generateRevisionProposalDraft(
       providerReturning(

--- a/tests/ai/generate-proposal.test.ts
+++ b/tests/ai/generate-proposal.test.ts
@@ -133,7 +133,8 @@ describe("proposal generation parsing", () => {
     expect(result.requirementSummary).toContain("水稻转录组分析要点");
     expect(result.missingInformation).toContain("样本数量");
     expect(result.proposalDraft).toContain("完整的方案内容");
-    expect(result.suggestedTitle).toBe("水稻转录组分析");
+    expect(result.suggestedTitle).toContain("水稻转录组分析");
+    expect(result.suggestedTitle).not.toContain("D.");
     expect(result.tags).toBeDefined();
   });
 
@@ -170,7 +171,7 @@ describe("proposal generation parsing", () => {
       },
     );
 
-    expect(result.suggestedTitle).toBe("水稻 WGCNA 共表达分析");
+    expect(result.suggestedTitle).toContain("水稻 WGCNA 共表达分析");
     expect(result.tags).toBeDefined();
     expect(result.tags!.productLine).toBe("RNA-seq");
     expect(result.tags!.keywordTags).toEqual(["WGCNA", "共表达网络"]);


### PR DESCRIPTION
修复 AI 输出 markdown 加粗标题（如 **D. 建议标题**）和代码围栏（\`\`\`json）时，标题和标签无法正确提取的问题。

- 正则兼容 markdown 加粗格式
- parseTags 剥离代码围栏标记后再解析 JSON
- 新增测试覆盖 markdown 格式的 AI 输出
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
