### PR TITLE
feat: add proposal-schema deep module (zod schemas + zod-to-json-schema) (#21)

### DIFF
--- a/lib/ai/proposal-schema.ts
+++ b/lib/ai/proposal-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { CaseTagsSchema } from "@/lib/domain/case-tags";
+
+const SuggestedTitleSchema = z.string().max(20);
+
+const SharedProposalFieldsSchema = {
+  proposalDraft: z.string(),
+  missingInformation: z.string(),
+  suggestedTitle: SuggestedTitleSchema,
+  tags: CaseTagsSchema,
+};
+
+export const InitialProposalJsonSchema = z.object({
+  requirementSummary: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export const RevisionProposalJsonSchema = z.object({
+  revisionNotes: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export type InitialProposalJson = z.infer<typeof InitialProposalJsonSchema>;
+export type RevisionProposalJson = z.infer<typeof RevisionProposalJsonSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "shadcn": "^4.6.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "zod": "^3.24.3"
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/tests/ai/proposal-schema.test.ts
+++ b/tests/ai/proposal-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  InitialProposalJsonSchema,
+  RevisionProposalJsonSchema,
+} from "@/lib/ai/proposal-schema";
+
+describe("proposal schemas", () => {
+  it("accepts valid initial and revision proposal JSON objects", () => {
+    const initialProposal = {
+      requirementSummary: "客户需要水稻转录组差异表达分析方案。",
+      missingInformation: "缺少样本数量与分组信息。",
+      proposalDraft: "1. 需求理解\n2. 实验设计\n3. 数据分析",
+      suggestedTitle: "水稻转录组分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "标准变异检测",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["差异表达", "转录组"],
+      },
+    };
+
+    const revisionProposal = {
+      revisionNotes: "已补充 WGCNA 分析与交付内容。",
+      proposalDraft: "1. 修订需求理解\n2. 修订实验设计\n3. 修订数据分析",
+      missingInformation: "仍缺少样本数量。",
+      suggestedTitle: "水稻WGCNA分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "个性化定制分析",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["WGCNA"],
+      },
+    };
+
+    expect(InitialProposalJsonSchema.parse(initialProposal)).toEqual(initialProposal);
+    expect(RevisionProposalJsonSchema.parse(revisionProposal)).toEqual(revisionProposal);
+  });
+
+  it("rejects suggestedTitle values longer than 20 characters", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "这是一个超过二十个字符的建议标题用于校验失败",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+
+  it("rejects tags containing enum values outside CaseTagsSchema", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "合法标题",
+        tags: {
+          productLine: "火箭制造",
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects objects missing required fields", () => {
+    expect(() =>
+      RevisionProposalJsonSchema.parse({
+        proposalDraft: "方案草稿",
+        missingInformation: "缺失信息",
+        suggestedTitle: "合法标题",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #21 — first slice of PRD #20.

## What this PR does

新增 `lib/ai/proposal-schema.ts` 深模块，用 zod 定义 AI 结构化 JSON 输出契约（初始生成 + 修订生成），并引入 `zod-to-json-schema` 依赖，供后续 #22 / #23 使用。

### 改动文件（共 4 个）

- `lib/ai/proposal-schema.ts`（新）— 导出 `InitialProposalJsonSchema`, `RevisionProposalJsonSchema` 与 `z.infer<...>` 推断类型
- `tests/ai/proposal-schema.test.ts`（新）— 4 个验收用例：happy / `suggestedTitle` 超 20 字符 / 非法 `tags` 枚举 / 缺必填字段
- `package.json`, `package-lock.json` — 引入 `zod-to-json-schema`

## Verification

- ✅ `npm test`：18 test files / 107 tests 全绿（含新增 schema 测试）
- ⚠️ `npm run lint` 在 main 上即存在预存的无关失败（`app/(app)/cases/[id]/title-editor.tsx` 的 `react-hooks/set-state-in-effect`），已在 #26 单独 triage 跟踪；本 PR 不修复以保持 surgical scope

## Out of scope（按 PRD 边界）

- 不修改 providers（`mock-provider.ts` / `openai-chat-provider.ts`） — 这是 #22 / #23
- 不删除 `extractSection / parseTags*` 正则函数 — 这是 #24
- 不修改 prompts、generate-proposal 管道、前端、prisma schema、`CaseTagsSchema`
- 不引入 OpenAI SDK / Vercel AI SDK

## Implementation note

由 AFK agent 在隔离 worktree 内实施，commit `a7a58a4`，已在本地通过 `npm test`。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
