### PR TITLE
feat: extend ProposalAiProvider with generateJson + mock impl (#22)

### DIFF
--- a/lib/ai/mock-provider.ts
+++ b/lib/ai/mock-provider.ts
@@ -1,4 +1,38 @@
+import { InitialProposalJsonSchema } from "./proposal-schema";
 import type { ProposalAiProvider } from "./types";
+
+const MOCK_INITIAL_PROPOSAL_JSON = InitialProposalJsonSchema.parse({
+  requirementSummary:
+    "根据客户原始描述，客户需要围绕生物信息数据开展个性化分析方案设计。",
+  missingInformation:
+    "样本类型、样本数量、物种、数据类型、期望交付物需要进一步确认。",
+  proposalDraft: [
+    "1. 客户需求理解",
+    "本方案根据客户提供的信息形成初步分析路线。",
+    "2. 分析目标",
+    "明确关键生物学问题并设计对应分析模块。",
+    "3. 样本与数据要求",
+    "请客户补充样本与数据细节。",
+    "4. 推荐分析流程",
+    "根据确认后的数据类型设计分析流程。",
+    "5. 交付结果与图表",
+    "交付分析报告、结果表格和核心图表。",
+    "6. 周期、注意事项与风险提示",
+    "周期需在样本和分析模块确认后评估。",
+    "7. 需要客户补充确认的问题",
+    "请确认样本、数据和重点分析目标。",
+  ].join("\n"),
+  suggestedTitle: "生物信息分析方案",
+  tags: {
+    productLine: "其他",
+    organism: "其他",
+    application: "基础科研",
+    analysisDepth: "仅下机数据",
+    sampleTypes: ["其他"],
+    platforms: ["Illumina"],
+    keywordTags: ["生物信息"],
+  },
+});
 
 export class MockProposalAiProvider implements ProposalAiProvider {
   async generateText(prompt: string) {
@@ -41,5 +75,9 @@ export class MockProposalAiProvider implements ProposalAiProvider {
       "",
       `--- prompt length: ${prompt.length}`,
     ].join("\n");
+  }
+
+  async generateJson<T>(_prompt: string): Promise<T> {
+    return MOCK_INITIAL_PROPOSAL_JSON as T;
   }
 }

--- a/lib/ai/proposal-schema.ts
+++ b/lib/ai/proposal-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { CaseTagsSchema } from "@/lib/domain/case-tags";
+
+const SuggestedTitleSchema = z.string().max(20);
+
+const SharedProposalFieldsSchema = {
+  proposalDraft: z.string(),
+  missingInformation: z.string(),
+  suggestedTitle: SuggestedTitleSchema,
+  tags: CaseTagsSchema,
+};
+
+export const InitialProposalJsonSchema = z.object({
+  requirementSummary: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export const RevisionProposalJsonSchema = z.object({
+  revisionNotes: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export type InitialProposalJson = z.infer<typeof InitialProposalJsonSchema>;
+export type RevisionProposalJson = z.infer<typeof RevisionProposalJsonSchema>;

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,4 +1,5 @@
 import type { CaseTags } from "@/lib/domain/case-tags";
+import type { ZodType } from "zod";
 
 export type InitialProposalInput = {
   originalRequestText: string;
@@ -22,4 +23,9 @@ export type ProposalDraftResult = {
 
 export interface ProposalAiProvider {
   generateText(prompt: string): Promise<string>;
+  generateJson<T>(
+    prompt: string,
+    schema: ZodType<T>,
+    schemaName: string,
+  ): Promise<T>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "shadcn": "^4.6.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "zod": "^3.24.3"
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/tests/ai/mock-provider.test.ts
+++ b/tests/ai/mock-provider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { MockProposalAiProvider } from "@/lib/ai/mock-provider";
+import { InitialProposalJsonSchema } from "@/lib/ai/proposal-schema";
+import { CaseTagsSchema } from "@/lib/domain/case-tags";
+
+describe("MockProposalAiProvider.generateJson", () => {
+  it("returns a complete object that parses with InitialProposalJsonSchema", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const result = await provider.generateJson(
+      "prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(InitialProposalJsonSchema.parse(result)).toEqual(result);
+    expect(result).toMatchObject({
+      requirementSummary: expect.any(String),
+      missingInformation: expect.any(String),
+      proposalDraft: expect.any(String),
+      suggestedTitle: expect.any(String),
+      tags: expect.any(Object),
+    });
+  });
+
+  it("returns tags that satisfy CaseTagsSchema", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const result = await provider.generateJson(
+      "prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(CaseTagsSchema.parse(result.tags)).toEqual(result.tags);
+  });
+
+  it("returns the same fixed output for different prompts", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const first = await provider.generateJson(
+      "short prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+    const second = await provider.generateJson(
+      "a very different and much longer prompt for the mock provider",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/ai/proposal-schema.test.ts
+++ b/tests/ai/proposal-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  InitialProposalJsonSchema,
+  RevisionProposalJsonSchema,
+} from "@/lib/ai/proposal-schema";
+
+describe("proposal schemas", () => {
+  it("accepts valid initial and revision proposal JSON objects", () => {
+    const initialProposal = {
+      requirementSummary: "客户需要水稻转录组差异表达分析方案。",
+      missingInformation: "缺少样本数量与分组信息。",
+      proposalDraft: "1. 需求理解\n2. 实验设计\n3. 数据分析",
+      suggestedTitle: "水稻转录组分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "标准变异检测",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["差异表达", "转录组"],
+      },
+    };
+
+    const revisionProposal = {
+      revisionNotes: "已补充 WGCNA 分析与交付内容。",
+      proposalDraft: "1. 修订需求理解\n2. 修订实验设计\n3. 修订数据分析",
+      missingInformation: "仍缺少样本数量。",
+      suggestedTitle: "水稻WGCNA分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "个性化定制分析",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["WGCNA"],
+      },
+    };
+
+    expect(InitialProposalJsonSchema.parse(initialProposal)).toEqual(initialProposal);
+    expect(RevisionProposalJsonSchema.parse(revisionProposal)).toEqual(revisionProposal);
+  });
+
+  it("rejects suggestedTitle values longer than 20 characters", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "这是一个超过二十个字符的建议标题用于校验失败",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+
+  it("rejects tags containing enum values outside CaseTagsSchema", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "合法标题",
+        tags: {
+          productLine: "火箭制造",
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects objects missing required fields", () => {
+    expect(() =>
+      RevisionProposalJsonSchema.parse({
+        proposalDraft: "方案草稿",
+        missingInformation: "缺失信息",
+        suggestedTitle: "合法标题",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #22 — slice 2 of PRD #20.

## What this PR does

扩展 `ProposalAiProvider` 接口新增 `generateJson<T>(prompt, schema, schemaName)` 方法，并在 `MockProposalAiProvider` 中实现该方法返回固定 JSON 对象（结构通过 `InitialProposalJsonSchema` 校验）。原 `generateText` 行为完全不变。

## Files

- `lib/ai/types.ts` — 接口签名扩展
- `lib/ai/mock-provider.ts` — `generateJson` 实现
- `tests/ai/mock-provider.test.ts` — 字段完整性 / `tags` 结构 / 不同 prompt 返回相同结构 用例

## Verification

- ✅ `npm test`：19 test files / 110 tests 全绿
- ⚠️ `npm run lint` 仅命中预存在的无关错误（[title-editor.tsx](app/(app)/cases/[id]/title-editor.tsx)），由 #26 / PR 处理；本 PR 未引入任何新 lint 错误

## Out of scope

- 不实现 OpenAI 版 `generateJson` — 这是 #23
- 不修改 `generate-proposal.ts` / prompts — 这是 #24
- 不引入 retry / 降级（这些属于 #23）

## Stacking

Base 分支为 `feat-21-proposal-schema`（PR #27），#21 合并后此 PR 的 base 可改为 `main` 或自然 fast-forward。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
