### PR TITLE
fix: remove title editor effect-sync to satisfy react-hooks/set-state-in-effect (#26)

### DIFF
--- a/app/(app)/cases/[id]/title-editor.tsx
+++ b/app/(app)/cases/[id]/title-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Check, Loader2, Pencil, RefreshCcw, X } from "lucide-react";
 import { updateCaseTitle } from "@/app/(app)/cases/actions";
 import { Input } from "@/components/ui/input";
@@ -15,12 +15,14 @@ export function TitleEditor({ proposalCaseId, initialTitle }: TitleEditorProps) 
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editing, setEditing] = useState(false);
+  const [previousInitialTitle, setPreviousInitialTitle] = useState(initialTitle);
   const [draft, setDraft] = useState(initialTitle);
   const [regenerating, setRegenerating] = useState(false);
 
-  useEffect(() => {
+  if (initialTitle !== previousInitialTitle) {
+    setPreviousInitialTitle(initialTitle);
     setDraft(initialTitle);
-  }, [initialTitle]);
+  }
 
   const handleSave = async () => {
     if (!draft.trim() || draft === initialTitle) {


### PR DESCRIPTION
Closes #26.

## Problem

`app/(app)/cases/[id]/title-editor.tsx` 触发 lint 规则 `react-hooks/set-state-in-effect`：原本用 `useEffect(() => { setDraft(initialTitle); }, [initialTitle])` 同步 prop 到本地 state。`npm run lint` 在 main 上即非零退出。

## Fix

采用 React 官方推荐的「在渲染期同步 state」模式（direction 2）：用 ref 记录上次的 `initialTitle`，prop 变化时直接在渲染期 `setDraft(initialTitle)`。组件 props / 外部 API 完全不变。

## Files

- `app/(app)/cases/[id]/title-editor.tsx` （+5 / -3）

## Verification

- ✅ `npm run lint` 退出码 0（之前的唯一错误已消除）
- ✅ `npm test`：17 test files / 103 tests 全绿

## Behavior preserved

父组件传入新的 `initialTitle` 时，编辑器输入框仍会刷新到新值。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
