### PR TITLE
feat: OpenAI Structured Outputs provider with retry + json_object fallback (#23)

### DIFF
--- a/lib/ai/generation-errors.ts
+++ b/lib/ai/generation-errors.ts
@@ -1,3 +1,10 @@
+export class AIGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AIGenerationError";
+  }
+}
+
 export function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
 }

--- a/lib/ai/get-proposal-ai-provider.ts
+++ b/lib/ai/get-proposal-ai-provider.ts
@@ -9,6 +9,7 @@ const DEFAULT_MODEL = "gpt-4o-mini";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_TOKENS = 5000;
 const DEFAULT_TEMPERATURE = 0.35;
+const DEFAULT_JSON_MODE = "json_schema";
 
 function parseIntegerOrDefault(raw: string | undefined, defaultValue: number) {
   if (!raw) return defaultValue;
@@ -32,6 +33,11 @@ function parseTemperatureOrDefault(raw: string | undefined, defaultValue: number
 function normalizeBaseUrl(raw: string | undefined): string {
   const trimmed = (raw ?? DEFAULT_BASE).trim().replace(/\/+$/, "");
   return trimmed.length > 0 ? trimmed : DEFAULT_BASE;
+}
+
+function normalizeJsonMode(raw: string | undefined): "json_schema" | "json_object" {
+  const normalized = (raw ?? DEFAULT_JSON_MODE).trim().toLowerCase();
+  return normalized === "json_object" ? "json_object" : "json_schema";
 }
 
 /**
@@ -69,6 +75,7 @@ export function getProposalAiProvider(): ProposalAiProvider {
       process.env.AI_TEMPERATURE,
       DEFAULT_TEMPERATURE,
     );
+    const jsonMode = normalizeJsonMode(process.env.AI_JSON_MODE);
 
     return new OpenAiChatProposalAiProvider({
       apiKey,
@@ -77,6 +84,7 @@ export function getProposalAiProvider(): ProposalAiProvider {
       timeoutMs,
       maxTokens,
       temperature,
+      jsonMode,
     });
   }
 

--- a/lib/ai/mock-provider.ts
+++ b/lib/ai/mock-provider.ts
@@ -1,4 +1,38 @@
+import { InitialProposalJsonSchema } from "./proposal-schema";
 import type { ProposalAiProvider } from "./types";
+
+const MOCK_INITIAL_PROPOSAL_JSON = InitialProposalJsonSchema.parse({
+  requirementSummary:
+    "根据客户原始描述，客户需要围绕生物信息数据开展个性化分析方案设计。",
+  missingInformation:
+    "样本类型、样本数量、物种、数据类型、期望交付物需要进一步确认。",
+  proposalDraft: [
+    "1. 客户需求理解",
+    "本方案根据客户提供的信息形成初步分析路线。",
+    "2. 分析目标",
+    "明确关键生物学问题并设计对应分析模块。",
+    "3. 样本与数据要求",
+    "请客户补充样本与数据细节。",
+    "4. 推荐分析流程",
+    "根据确认后的数据类型设计分析流程。",
+    "5. 交付结果与图表",
+    "交付分析报告、结果表格和核心图表。",
+    "6. 周期、注意事项与风险提示",
+    "周期需在样本和分析模块确认后评估。",
+    "7. 需要客户补充确认的问题",
+    "请确认样本、数据和重点分析目标。",
+  ].join("\n"),
+  suggestedTitle: "生物信息分析方案",
+  tags: {
+    productLine: "其他",
+    organism: "其他",
+    application: "基础科研",
+    analysisDepth: "仅下机数据",
+    sampleTypes: ["其他"],
+    platforms: ["Illumina"],
+    keywordTags: ["生物信息"],
+  },
+});
 
 export class MockProposalAiProvider implements ProposalAiProvider {
   async generateText(prompt: string) {
@@ -41,5 +75,9 @@ export class MockProposalAiProvider implements ProposalAiProvider {
       "",
       `--- prompt length: ${prompt.length}`,
     ].join("\n");
+  }
+
+  async generateJson<T>(_prompt: string): Promise<T> {
+    return MOCK_INITIAL_PROPOSAL_JSON as T;
   }
 }

--- a/lib/ai/openai-chat-provider.ts
+++ b/lib/ai/openai-chat-provider.ts
@@ -1,3 +1,6 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { ZodType } from "zod";
+import { AIGenerationError } from "./generation-errors";
 import type { ProposalAiProvider } from "./types";
 
 type OpenAiChatProviderOptions = {
@@ -9,6 +12,7 @@ type OpenAiChatProviderOptions = {
   timeoutMs: number;
   maxTokens: number;
   temperature: number;
+  jsonMode?: "json_schema" | "json_object";
 };
 
 type ChatCompletionsResponse = {
@@ -18,6 +22,26 @@ type ChatCompletionsResponse = {
   }>;
   error?: { message?: string };
 };
+
+type ChatCompletionsRequestBody = {
+  model: string;
+  messages: Array<{ role: "user"; content: string }>;
+  max_tokens: number;
+  temperature: number;
+  response_format?:
+    | {
+        type: "json_schema";
+        json_schema: {
+          name: string;
+          strict: true;
+          schema: Record<string, unknown>;
+        };
+      }
+    | { type: "json_object" };
+};
+
+const INVALID_JSON_RETRY_HINT =
+  "上次输出不是合法 JSON，请只返回符合 schema 的 JSON 对象";
 
 export class OpenAiChatProposalAiProvider implements ProposalAiProvider {
   private readonly options: OpenAiChatProviderOptions;
@@ -45,6 +69,115 @@ export class OpenAiChatProposalAiProvider implements ProposalAiProvider {
           max_tokens: this.options.maxTokens,
           temperature: this.options.temperature,
         }),
+      });
+
+      const body = (await res.json()) as ChatCompletionsResponse;
+
+      if (!res.ok) {
+        const msg = body.error?.message ?? res.statusText;
+        throw new Error(`AI 请求失败 (${res.status}): ${msg}`);
+      }
+
+      const choice = body.choices?.[0];
+      if (choice?.finish_reason === "length") {
+        throw new Error(
+          "AI 返回内容被截断，请提高 AI_MAX_TOKENS 后重新生成。",
+        );
+      }
+
+      const text = choice?.message?.content;
+      if (typeof text !== "string" || !text.trim()) {
+        throw new Error("AI 返回内容为空");
+      }
+
+      return text;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async generateJson<T>(
+    prompt: string,
+    schema: ZodType<T>,
+    schemaName: string,
+  ): Promise<T> {
+    const jsonSchema = zodToJsonSchema(schema, {
+      name: schemaName,
+      target: "openAi",
+    }) as Record<string, unknown>;
+
+    const responseFormat =
+      this.options.jsonMode === "json_object"
+        ? { type: "json_object" as const }
+        : {
+            type: "json_schema" as const,
+            json_schema: {
+              name: schemaName,
+              strict: true as const,
+              schema: jsonSchema,
+            },
+          };
+
+    let retryPrompt = this.buildJsonPrompt(prompt, jsonSchema);
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const text = await this.requestContent(retryPrompt, responseFormat);
+
+      try {
+        const parsedJson = JSON.parse(text) as unknown;
+        return schema.parse(parsedJson);
+      } catch (error) {
+        if (attempt === 1) {
+          const detail = error instanceof Error ? `: ${error.message}` : "";
+          throw new AIGenerationError(`schema 校验失败${detail}`);
+        }
+
+        retryPrompt = `${this.buildJsonPrompt(prompt, jsonSchema)}\n\n${INVALID_JSON_RETRY_HINT}`;
+      }
+    }
+
+    throw new AIGenerationError("schema 校验失败");
+  }
+
+  private buildJsonPrompt(
+    prompt: string,
+    jsonSchema: Record<string, unknown>,
+  ): string {
+    if (this.options.jsonMode !== "json_object") {
+      return prompt;
+    }
+
+    return `${prompt}\n\n请返回 JSON 对象，字段要求如下：${JSON.stringify(jsonSchema)}`;
+  }
+
+  private async requestContent(
+    prompt: string,
+    response_format?: ChatCompletionsRequestBody["response_format"],
+  ): Promise<string> {
+    const url = `${this.options.baseUrl}/chat/completions`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      const requestBody: ChatCompletionsRequestBody = {
+        model: this.options.model,
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: this.options.maxTokens,
+        temperature: this.options.temperature,
+      };
+
+      if (response_format) {
+        requestBody.response_format = response_format;
+      }
+
+      const res = await fetch(url, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.options.apiKey}`,
+        },
+        body: JSON.stringify(requestBody),
       });
 
       const body = (await res.json()) as ChatCompletionsResponse;

--- a/lib/ai/proposal-schema.ts
+++ b/lib/ai/proposal-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { CaseTagsSchema } from "@/lib/domain/case-tags";
+
+const SuggestedTitleSchema = z.string().max(20);
+
+const SharedProposalFieldsSchema = {
+  proposalDraft: z.string(),
+  missingInformation: z.string(),
+  suggestedTitle: SuggestedTitleSchema,
+  tags: CaseTagsSchema,
+};
+
+export const InitialProposalJsonSchema = z.object({
+  requirementSummary: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export const RevisionProposalJsonSchema = z.object({
+  revisionNotes: z.string(),
+  ...SharedProposalFieldsSchema,
+});
+
+export type InitialProposalJson = z.infer<typeof InitialProposalJsonSchema>;
+export type RevisionProposalJson = z.infer<typeof RevisionProposalJsonSchema>;

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,4 +1,5 @@
 import type { CaseTags } from "@/lib/domain/case-tags";
+import type { ZodType } from "zod";
 
 export type InitialProposalInput = {
   originalRequestText: string;
@@ -22,4 +23,9 @@ export type ProposalDraftResult = {
 
 export interface ProposalAiProvider {
   generateText(prompt: string): Promise<string>;
+  generateJson<T>(
+    prompt: string,
+    schema: ZodType<T>,
+    schemaName: string,
+  ): Promise<T>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "shadcn": "^4.6.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "zod": "^3.24.3"
+        "zod": "^3.24.3",
+        "zod-to-json-schema": "^3.25.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/tests/ai/mock-provider.test.ts
+++ b/tests/ai/mock-provider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { MockProposalAiProvider } from "@/lib/ai/mock-provider";
+import { InitialProposalJsonSchema } from "@/lib/ai/proposal-schema";
+import { CaseTagsSchema } from "@/lib/domain/case-tags";
+
+describe("MockProposalAiProvider.generateJson", () => {
+  it("returns a complete object that parses with InitialProposalJsonSchema", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const result = await provider.generateJson(
+      "prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(InitialProposalJsonSchema.parse(result)).toEqual(result);
+    expect(result).toMatchObject({
+      requirementSummary: expect.any(String),
+      missingInformation: expect.any(String),
+      proposalDraft: expect.any(String),
+      suggestedTitle: expect.any(String),
+      tags: expect.any(Object),
+    });
+  });
+
+  it("returns tags that satisfy CaseTagsSchema", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const result = await provider.generateJson(
+      "prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(CaseTagsSchema.parse(result.tags)).toEqual(result.tags);
+  });
+
+  it("returns the same fixed output for different prompts", async () => {
+    const provider = new MockProposalAiProvider();
+
+    const first = await provider.generateJson(
+      "short prompt",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+    const second = await provider.generateJson(
+      "a very different and much longer prompt for the mock provider",
+      InitialProposalJsonSchema,
+      "InitialProposalJson",
+    );
+
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/ai/openai-chat-provider.test.ts
+++ b/tests/ai/openai-chat-provider.test.ts
@@ -1,5 +1,51 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { AIGenerationError } from "@/lib/ai/generation-errors";
 import { OpenAiChatProposalAiProvider } from "@/lib/ai/openai-chat-provider";
+
+const ProposalSchema = z.object({
+  title: z.string(),
+  count: z.number(),
+});
+
+function createProvider(jsonMode?: "json_schema" | "json_object") {
+  return new OpenAiChatProposalAiProvider({
+    apiKey: "test-key",
+    baseUrl: "https://example.test/v1",
+    model: "test-model",
+    timeoutMs: 1000,
+    maxTokens: 5000,
+    temperature: 0.2,
+    jsonMode,
+  });
+}
+
+function createResponse(content: string, init?: ResponseInit) {
+  return new Response(
+    JSON.stringify({
+      choices: [
+        {
+          finish_reason: "stop",
+          message: { content },
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    },
+  );
+}
+
+function getRequestBody() {
+  const mock = vi.mocked(globalThis.fetch);
+  const [, init] = mock.mock.calls.at(-1) ?? [];
+  return JSON.parse(String(init?.body)) as {
+    messages: Array<{ role: string; content: string }>;
+    response_format?: unknown;
+  };
+}
 
 describe("OpenAiChatProposalAiProvider", () => {
   afterEach(() => {
@@ -21,17 +67,107 @@ describe("OpenAiChatProposalAiProvider", () => {
       ),
     );
 
-    const provider = new OpenAiChatProposalAiProvider({
-      apiKey: "test-key",
-      baseUrl: "https://example.test/v1",
-      model: "test-model",
-      timeoutMs: 1000,
-      maxTokens: 5000,
-      temperature: 0.2,
-    });
+    const provider = createProvider();
 
     await expect(provider.generateText("prompt")).rejects.toThrow(
       "AI 返回内容被截断",
     );
+  });
+
+  it("returns parsed JSON that passes schema validation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      createResponse('{ "title": "valid", "count": 2 }'),
+    );
+
+    const provider = createProvider();
+
+    await expect(
+      provider.generateJson("prompt", ProposalSchema, "ProposalSchema"),
+    ).resolves.toEqual({
+      title: "valid",
+      count: 2,
+    });
+
+    expect(getRequestBody().response_format).toMatchObject({
+      type: "json_schema",
+      json_schema: {
+        name: "ProposalSchema",
+        strict: true,
+      },
+    });
+  });
+
+  it("retries once when the first response is not valid JSON", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(createResponse("not-json"))
+      .mockResolvedValueOnce(createResponse('{ "title": "valid", "count": 2 }'));
+
+    const provider = createProvider();
+
+    await expect(
+      provider.generateJson("prompt", ProposalSchema, "ProposalSchema"),
+    ).resolves.toEqual({
+      title: "valid",
+      count: 2,
+    });
+
+    const [, secondInit] = fetchMock.mock.calls[1] ?? [];
+    const secondBody = JSON.parse(String(secondInit?.body)) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(secondBody.messages[0]?.content).toContain(
+      "上次输出不是合法 JSON，请只返回符合 schema 的 JSON 对象",
+    );
+  });
+
+  it("retries once when the first response fails zod validation", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createResponse('{ "title": "valid", "count": "2" }'))
+      .mockResolvedValueOnce(createResponse('{ "title": "valid", "count": 2 }'));
+
+    const provider = createProvider();
+
+    await expect(
+      provider.generateJson("prompt", ProposalSchema, "ProposalSchema"),
+    ).resolves.toEqual({
+      title: "valid",
+      count: 2,
+    });
+  });
+
+  it("throws AIGenerationError after two schema-related failures", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createResponse("not-json"))
+      .mockResolvedValueOnce(createResponse('{ "title": "still wrong", "count": "2" }'));
+
+    const provider = createProvider();
+    const result = provider.generateJson("prompt", ProposalSchema, "ProposalSchema");
+
+    await expect(result).rejects.toBeInstanceOf(AIGenerationError);
+    await expect(result).rejects.toThrow("schema 校验失败");
+  });
+
+  it("uses json_object mode and appends schema guidance to the prompt", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      createResponse('{ "title": "valid", "count": 2 }'),
+    );
+
+    const provider = createProvider("json_object");
+
+    await expect(
+      provider.generateJson("prompt", ProposalSchema, "ProposalSchema"),
+    ).resolves.toEqual({
+      title: "valid",
+      count: 2,
+    });
+
+    const requestBody = getRequestBody();
+    expect(requestBody.response_format).toEqual({ type: "json_object" });
+    expect(requestBody.messages[0]?.content).toContain(
+      "请返回 JSON 对象，字段要求如下：",
+    );
+    expect(requestBody.messages[0]?.content).toContain('"title"');
+    expect(requestBody.messages[0]?.content).toContain('"count"');
   });
 });

--- a/tests/ai/proposal-schema.test.ts
+++ b/tests/ai/proposal-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  InitialProposalJsonSchema,
+  RevisionProposalJsonSchema,
+} from "@/lib/ai/proposal-schema";
+
+describe("proposal schemas", () => {
+  it("accepts valid initial and revision proposal JSON objects", () => {
+    const initialProposal = {
+      requirementSummary: "客户需要水稻转录组差异表达分析方案。",
+      missingInformation: "缺少样本数量与分组信息。",
+      proposalDraft: "1. 需求理解\n2. 实验设计\n3. 数据分析",
+      suggestedTitle: "水稻转录组分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "标准变异检测",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["差异表达", "转录组"],
+      },
+    };
+
+    const revisionProposal = {
+      revisionNotes: "已补充 WGCNA 分析与交付内容。",
+      proposalDraft: "1. 修订需求理解\n2. 修订实验设计\n3. 修订数据分析",
+      missingInformation: "仍缺少样本数量。",
+      suggestedTitle: "水稻WGCNA分析",
+      tags: {
+        productLine: "RNA-seq",
+        organism: "水稻",
+        application: "表达分析",
+        analysisDepth: "个性化定制分析",
+        sampleTypes: ["叶片"],
+        platforms: ["Illumina"],
+        keywordTags: ["WGCNA"],
+      },
+    };
+
+    expect(InitialProposalJsonSchema.parse(initialProposal)).toEqual(initialProposal);
+    expect(RevisionProposalJsonSchema.parse(revisionProposal)).toEqual(revisionProposal);
+  });
+
+  it("rejects suggestedTitle values longer than 20 characters", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "这是一个超过二十个字符的建议标题用于校验失败",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+
+  it("rejects tags containing enum values outside CaseTagsSchema", () => {
+    expect(() =>
+      InitialProposalJsonSchema.parse({
+        requirementSummary: "需求摘要",
+        missingInformation: "缺失信息",
+        proposalDraft: "方案草稿",
+        suggestedTitle: "合法标题",
+        tags: {
+          productLine: "火箭制造",
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects objects missing required fields", () => {
+    expect(() =>
+      RevisionProposalJsonSchema.parse({
+        proposalDraft: "方案草稿",
+        missingInformation: "缺失信息",
+        suggestedTitle: "合法标题",
+        tags: {},
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #23 — slice 3 of PRD #20.

## What this PR does

在 `OpenAiChatProposalAiProvider` 中实现 `generateJson<T>(prompt, schema, schemaName)`：使用 OpenAI Structured Outputs（`response_format.json_schema`）让模型 server 端按 JSON Schema 输出，客户端解析后再用 zod 二次校验，失败时自动 retry 一次，双重失败抛 `AIGenerationError`。新增 `AI_JSON_MODE=json_object` 降级路径以兼容不支持 `json_schema` 的中转 / 自建模型。

## Files

- `lib/ai/generation-errors.ts` — 新增 `AIGenerationError` 类
- `lib/ai/openai-chat-provider.ts` — 实现 `generateJson` + retry + 降级（+133 / 0）
- `lib/ai/get-proposal-ai-provider.ts` — 读取 `AI_JSON_MODE` 环境变量并组装到 provider（与其它 `AI_*` 配置集中处理）
- `tests/ai/openai-chat-provider.test.ts` — 覆盖 happy / parse-fail-retry / zod-fail-retry / 双重失败抛 `AIGenerationError` / `json_object` 模式请求体形状

## Verification

- ✅ `npm test`：19 test files / 115 tests 全绿
- ⚠️ `npm run lint` 仅命中预存在的无关错误（[title-editor.tsx](app/(app)/cases/[id]/title-editor.tsx)），由 #26 / PR #29 处理；本 PR 未引入任何新 lint 错误

## Out of scope

- 不修改 `generate-proposal.ts` / prompts — 这是 #24
- 不引入 OpenAI SDK / Vercel AI SDK，继续用 `fetch`
- 不增加超过一次的 retry（PRD 锁定）

## Stacking

Base 分支为 `feat-22-provider-generate-json`（PR #28）。Stack: PR #27 → PR #28 → 本 PR。#21/#22 合并后此 PR 可逐步前移 base 至 main。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
