### PR TITLE
fix: resolve pre-existing tsc --noEmit errors + add typecheck script (#32)

### DIFF
--- a/app/(app)/cases/[id]/page.tsx
+++ b/app/(app)/cases/[id]/page.tsx
@@ -73,7 +73,7 @@ export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
         originalRequestText: proposalCase.originalRequestText,
         requirementSummary: proposalCase.requirementSummary,
       })
-    : { results: [], usedFallback: false };
+    : { results: [] };
   const canConfirmRevision = canConfirmCurrentRevision(proposalCase.status);
   const currentUser = await getCurrentUser();
   const isAdmin = currentUser.role === "ADMIN";

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/tests/app/cases/update-case-tags.test.ts
+++ b/tests/app/cases/update-case-tags.test.ts
@@ -21,7 +21,7 @@ describe("updateCaseTags", () => {
   });
 
   it("updates tag fields with valid input", async () => {
-    mockedPrisma.proposalCase.update.mockResolvedValue({} as never);
+    vi.mocked(prisma.proposalCase.update).mockResolvedValue({} as never);
 
     await updateCaseTags("case-1", {
       organism: "小麦",
@@ -38,7 +38,7 @@ describe("updateCaseTags", () => {
   });
 
   it("sets updatedAt on tag update", async () => {
-    mockedPrisma.proposalCase.update.mockResolvedValue({} as never);
+    vi.mocked(prisma.proposalCase.update).mockResolvedValue({} as never);
 
     await updateCaseTags("case-1", { organism: "水稻" });
 
@@ -82,7 +82,7 @@ describe("reExtractCaseTags", () => {
   it("calls AI provider with case text and saves extracted tags", async () => {
     const { reExtractCaseTags } = await import("@/lib/db/proposal-repository");
 
-    mockedPrisma.proposalCase.findUnique.mockResolvedValue({
+    vi.mocked(prisma.proposalCase.findUnique).mockResolvedValue({
       id: "case-1",
       originalRequestText: "需要小麦BSA-seq分析",
       requirementSummary: "小麦抗病基因定位",
@@ -95,7 +95,7 @@ describe("reExtractCaseTags", () => {
       ),
     };
 
-    mockedPrisma.proposalCase.update.mockResolvedValue({} as never);
+    vi.mocked(prisma.proposalCase.update).mockResolvedValue({} as never);
 
     await reExtractCaseTags("case-1", mockProvider);
 
@@ -113,7 +113,7 @@ describe("reExtractCaseTags", () => {
   it("saves with null tags when AI returns unparseable text", async () => {
     const { reExtractCaseTags } = await import("@/lib/db/proposal-repository");
 
-    mockedPrisma.proposalCase.findUnique.mockResolvedValue({
+    vi.mocked(prisma.proposalCase.findUnique).mockResolvedValue({
       id: "case-1",
       originalRequestText: "需求文本",
       requirementSummary: null,
@@ -124,7 +124,7 @@ describe("reExtractCaseTags", () => {
       generateText: vi.fn().mockResolvedValue("这不是JSON"),
     };
 
-    mockedPrisma.proposalCase.update.mockResolvedValue({} as never);
+    vi.mocked(prisma.proposalCase.update).mockResolvedValue({} as never);
 
     await reExtractCaseTags("case-1", mockProvider);
 

--- a/tests/domain/proposal-workflow.test.ts
+++ b/tests/domain/proposal-workflow.test.ts
@@ -83,8 +83,11 @@ describe("proposal workflow helpers", () => {
   it("confirms a revision with analyst text", () => {
     expect(
       markRevisionConfirmed({
+        revisionNumber: 1,
+        customerFeedbackText: null,
         aiDraft: "AI 草稿",
         analystConfirmedText: "分析人员确认版",
+        revisionNotes: null,
       }).analystConfirmedText,
     ).toBe("分析人员确认版");
   });
@@ -123,15 +126,22 @@ describe("proposal workflow helpers", () => {
   it("rejects empty analyst confirmed text", () => {
     expect(() =>
       markRevisionConfirmed({
+        revisionNumber: 1,
+        customerFeedbackText: null,
         aiDraft: "AI 草稿",
         analystConfirmedText: " ",
+        revisionNotes: null,
       }),
     ).toThrow("Analyst confirmed text is required");
   });
 
   it("sets sent timestamp when PM sends a confirmed proposal", () => {
     const sent = markRevisionSent({
+      revisionNumber: 1,
+      customerFeedbackText: null,
+      aiDraft: "AI 草稿",
       analystConfirmedText: "确认方案",
+      revisionNotes: null,
       sentAt: new Date("2026-04-27T00:00:00.000Z"),
     });
 


### PR DESCRIPTION
Closes #32.

## What this PR does

修复 `tsc --noEmit` 在 main 上报告的预存在 TypeScript 错误，并把 `typecheck` 脚本加入 `package.json` 防止再次漂移。

## Files (4 changed, +18 / -7)

- `app/(app)/cases/[id]/page.tsx` — 删除字面量中无人消费的 `usedFallback: false`（搜索后确认 case 详情页内部无 reader；service 层及其测试中保留）
- `tests/app/cases/update-case-tags.test.ts` — Prisma 方法 mock 改用 `vi.mocked(prisma.proposalCase.update)` / `vi.mocked(prisma.proposalCase.findUnique)`，断言保持不变
- `tests/domain/proposal-workflow.test.ts` — `RevisionDraft` fixtures 补齐 `revisionNumber` / `customerFeedbackText` / `revisionNotes` / `aiDraft` 等必填字段（无 `as any`）
- `package.json` — 新增 `"typecheck": "tsc --noEmit"`

## Verification

- ✅ `npm run typecheck`：仅余 1 处与 PR #31 范围重叠的错误（`lib/db/proposal-repository.ts:57: Cannot find name 'CaseTags'`），PR #31 已添加该 import，合并后即清零
- ✅ `npm test`：17 test files / 103 tests 全绿
- ⚠️ `npm run lint`：状态与 baseline 一致（仅 PR #29 修复的 `title-editor.tsx` 错误）

## Out of scope

- 未触碰 `lib/db/proposal-repository.ts`（与 PR #31 重叠，由其修复）
- 未重构 case 详情页渲染逻辑、Prisma mock 框架、`RevisionDraft` 类型定义
- 不引入新依赖

## Merge ordering

可独立 merge，与 #27/#28/#30/#31 chain 无 base 依赖。`proposal-repository.ts:57` 的最后一处错误会在 PR #31 merge 后自动消除。建议合并顺序：本 PR + PR #29 → main，再 squash chain。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bioshaun/persona_seq/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
